### PR TITLE
Support `base-4.6.*`

### DIFF
--- a/promises.cabal
+++ b/promises.cabal
@@ -34,5 +34,5 @@ library
     Data.Promise
 
   build-depends:
-    base      >= 4.7 && < 5,
+    base      >= 4.6 && < 5,
     primitive >= 0.6 && < 1

--- a/src/Data/Promise.hs
+++ b/src/Data/Promise.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
+#if MIN_VERSION_base(4,7,0)
 {-# LANGUAGE RoleAnnotations #-}
+#endif
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Trustworthy #-}
 {-# OPTIONS_GHC -fno-cse -fno-full-laziness #-}
@@ -99,7 +101,9 @@ drive d mv v = unsafePerformIO $ tryTakeMVar v >>= \case
 newtype Lazy s a = Lazy { getLazy :: forall x. MVar (Maybe (IO (K s x))) -> IO (K s a) }
   deriving Typeable
 
+#if MIN_VERSION_base(4,7,0)
 type role Lazy nominal representational
+#endif
 
 instance Functor (Lazy s) where
   fmap f (Lazy m) = Lazy $ \mv -> fmap go (m mv) where


### PR DESCRIPTION
This is part of trying to make the downstream `discrimination` package installable using `ghc-7.6.3`, which is the version distributed by Debian stable
